### PR TITLE
more flexible handling of checking  hostnames and ssl-certs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,15 @@
 
+# ignore local test config
 /src/test/resource/config.properties
-/.idea/
+
+# ignore maven artifacts
 /target/
+
+# ignore ide stuff: idea 
+/.idea/
 /*.iml
+
+# ignore ide stuff: eclipse 
+/.settings/
+.classpath
+.project

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: java
+
+jdk:
+- openjdk8
+
+# see https://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure
+sudo: false
+
+# cache the build tool's caches
+cache:
+  directories:
+  - $HOME/.m2
+  - $HOME/.gradle

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,6 @@ cache:
   directories:
   - $HOME/.m2
   - $HOME/.gradle
+
+install: true
+script: mvn clean package -DskipTests=true

--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 A Service to interact with Jira Rest API
 
 [![Build Status](https://travis-ci.com/dhamann/JiraRestService.svg?branch=master)](https://travis-ci.com/dhamann/JiraRestService)
+
+[![Codeship Status for dhamann/JiraRestService](https://app.codeship.com/projects/90c2a270-0e9d-0137-02b5-029904a44272/status?branch=master)](https://app.codeship.com/projects/326890)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # JiraRestService
 A Service to interact with Jira Rest API
+
+[![Build Status](https://travis-ci.com/dhamann/JiraRestService.svg?branch=master)](https://travis-ci.com/dhamann/JiraRestService)

--- a/src/main/java/com/github/cschulc/jirarestservice/util/HttpClientFactory.java
+++ b/src/main/java/com/github/cschulc/jirarestservice/util/HttpClientFactory.java
@@ -1,0 +1,155 @@
+package com.github.cschulc.jirarestservice.util;
+
+import static com.github.cschulc.jirarestservice.util.HttpClientFactory.HostnameVerificationStrategy.*;
+import static com.github.cschulc.jirarestservice.util.HttpClientFactory.TrustReductionStrategy.*;
+
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.conn.ssl.DefaultHostnameVerifier;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.TrustAllStrategy;
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.ssl.SSLContextBuilder;
+
+
+public class HttpClientFactory {
+	
+	public enum TrustReductionStrategy {
+		TRUST_SELFSIGNED, TRUST_ALL
+	}
+
+	public enum HostnameVerificationStrategy {
+		VERIFY_HOSTNAMES, DONT_VERIFY_HOSTNAMES
+	}
+	
+	/**
+	 * @param credsProvider the credentials to use
+	 * @return
+	 */
+	public static CloseableHttpClient getDefaultClient(CredentialsProvider credsProvider) {
+		return getDefaultClientBuilder(credsProvider).build();
+	}
+
+	/**
+	 * More flexibility when creating the CloseableHttpClient
+	 * 
+	 * @param credsProvider the credentials to use
+	 * @param trustStrategy the SSL-Cert-Trust-Strategy
+	 * @param hostnameVerificationStrategy the Host-Name-Verification-Strategy
+	 * @return a CloseableHttpClient configured as specified 
+	 * 
+	 * @throws KeyManagementException
+	 * @throws NoSuchAlgorithmException
+	 * @throws KeyStoreException
+	 */
+	public static CloseableHttpClient getClient(CredentialsProvider credsProvider, TrustReductionStrategy trustStrategy, HostnameVerificationStrategy hostnameVerificationStrategy) 
+			throws KeyManagementException, NoSuchAlgorithmException, KeyStoreException {
+		
+		return getDefaultClientBuilder(credsProvider)
+				.setSSLSocketFactory(getCustomSSLSocketFactory(trustStrategy, hostnameVerificationStrategy))
+				.build();
+	}
+
+	/**
+	 * @param credsProvider the credentials to use
+	 * @return a CloseableHttpClient that trusts all self-signed SSL Certificates and validates Hostnames
+	 * 
+	 * @throws KeyManagementException
+	 * @throws NoSuchAlgorithmException
+	 * @throws KeyStoreException
+	 */
+	public static CloseableHttpClient getTrustSelfsignedClient(CredentialsProvider credsProvider) 
+			throws KeyManagementException, NoSuchAlgorithmException, KeyStoreException {
+		
+		return getDefaultClientBuilder(credsProvider)
+				.setSSLSocketFactory(
+						getCustomSSLSocketFactory(TRUST_SELFSIGNED, VERIFY_HOSTNAMES)).build();
+	}
+	
+	/**
+	 * @param credsProvider the credentials to use
+	 * @return a CloseableHttpClient that neither checks SSL Certificates nor validates Hostnames
+	 * 
+	 * @throws KeyManagementException
+	 * @throws NoSuchAlgorithmException
+	 * @throws KeyStoreException
+	 */
+	public static CloseableHttpClient getTrustAllClient(CredentialsProvider credsProvider) 
+			throws KeyManagementException, NoSuchAlgorithmException, KeyStoreException {
+		
+		return getDefaultClientBuilder(credsProvider)
+				.setSSLSocketFactory(
+						getCustomSSLSocketFactory(TRUST_ALL, DONT_VERIFY_HOSTNAMES)).build();
+	}
+	
+	/**
+	 *   
+	 * @param credsProvider the credentials to use
+	 * @return the base HttpClientBuilder Object that can be configured lateron
+	 */
+	private static HttpClientBuilder getDefaultClientBuilder(CredentialsProvider credsProvider) {
+		return HttpClients.custom().setDefaultCredentialsProvider(credsProvider);
+	}
+	
+	/**
+	 * @param trustStrategy
+	 * @param hostnameVerificationStrategy
+	 * @return
+	 * @throws KeyManagementException
+	 * @throws NoSuchAlgorithmException
+	 * @throws KeyStoreException
+	 */
+	private static SSLConnectionSocketFactory getCustomSSLSocketFactory(TrustReductionStrategy trustStrategy, HostnameVerificationStrategy hostnameVerificationStrategy) 
+			throws KeyManagementException, NoSuchAlgorithmException, KeyStoreException {
+		
+		return new SSLConnectionSocketFactory(
+						getCustomSSLContext(trustStrategy), 
+						getCustomHostnameVerifier(hostnameVerificationStrategy));
+	}
+
+	/**
+	 * @param strategy
+	 * @return
+	 * @throws KeyManagementException
+	 * @throws NoSuchAlgorithmException
+	 * @throws KeyStoreException
+	 */
+	private static SSLContext getCustomSSLContext(TrustReductionStrategy strategy) 
+			throws KeyManagementException, NoSuchAlgorithmException, KeyStoreException {
+		
+		SSLContextBuilder builder = SSLContextBuilder.create();
+		switch (strategy) {
+			case TRUST_ALL:
+				return builder.loadTrustMaterial(new TrustAllStrategy()).build();
+			case TRUST_SELFSIGNED:
+				return builder.loadTrustMaterial(new TrustSelfSignedStrategy()).build();
+			default:
+				throw new NoSuchAlgorithmException();
+			}
+	}
+
+	/**
+	 * @param strategy
+	 * @return
+	 */
+	private static HostnameVerifier getCustomHostnameVerifier(HostnameVerificationStrategy strategy) {
+		switch (strategy) {
+			case DONT_VERIFY_HOSTNAMES:
+				return new NoopHostnameVerifier();
+			case VERIFY_HOSTNAMES:
+				return new DefaultHostnameVerifier();
+			default:
+				throw new IllegalArgumentException();
+		}
+	}
+}

--- a/src/test/java/com/github/cschulc/jirarestservice/test/BaseTest.java
+++ b/src/test/java/com/github/cschulc/jirarestservice/test/BaseTest.java
@@ -2,12 +2,19 @@ package com.github.cschulc.jirarestservice.test;
 
 
 import com.github.cschulc.jirarestservice.JiraRestService;
+import com.github.cschulc.jirarestservice.util.HttpClientFactory;
+import com.github.cschulc.jirarestservice.util.HttpClientFactory.HostnameVerificationStrategy;
+import com.github.cschulc.jirarestservice.util.HttpClientFactory.TrustReductionStrategy;
+
 import org.testng.annotations.BeforeClass;
 
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -29,6 +36,8 @@ public class BaseTest {
     static final String ISSUEKEY_TO_SEARCH = "DEMO-1";
     static final String PROJECT_TO_SEARCH = "DEMO";
 
+    static final TrustReductionStrategy sslCertTrustStrategy = HttpClientFactory.TrustReductionStrategy.TRUST_SELFSIGNED;
+    static final HostnameVerificationStrategy hostnameVerificationStrategy = HttpClientFactory.HostnameVerificationStrategy.VERIFY_HOSTNAMES; 
 
     String testSystemUrl;
     String login;
@@ -37,13 +46,13 @@ public class BaseTest {
     JiraRestService restService;
 
     @BeforeClass
-    public void connect() throws URISyntaxException, IOException, ExecutionException, InterruptedException {
+    public void connect() throws URISyntaxException, IOException, ExecutionException, InterruptedException, KeyManagementException, NoSuchAlgorithmException, KeyStoreException {
         loadConfig();
         ExecutorService executorService = Executors.newFixedThreadPool(100);
 //        ProxyHost proxy = new ProxyHost("proxy", 3128);
         URI uri = new URI(testSystemUrl);
         restService = new JiraRestService(executorService);
-        restService.connect(uri, login, password);
+        restService.connect(uri, login, password, sslCertTrustStrategy);
     }
 
     private void loadConfig() throws IOException {

--- a/src/test/java/com/github/cschulc/jirarestservice/util/HttpClientFactoryTest.java
+++ b/src/test/java/com/github/cschulc/jirarestservice/util/HttpClientFactoryTest.java
@@ -1,0 +1,69 @@
+package com.github.cschulc.jirarestservice.util;
+
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.github.cschulc.jirarestservice.test.BaseTest;
+
+public class HttpClientFactoryTest extends BaseTest{
+
+	@Test
+	public void testGetDefaultClient() {
+        String host = "";
+        int port = 443;
+        String scheme = "http";
+        if (port == 443) scheme = "https";
+        HttpHost target = new HttpHost(host, port, scheme);
+        CredentialsProvider credsProvider = new BasicCredentialsProvider();
+        credsProvider.setCredentials(
+                new AuthScope(target.getHostName(), target.getPort()),
+                new UsernamePasswordCredentials("", ""));
+        
+		Assert.assertNotNull(HttpClientFactory.getDefaultClient(credsProvider));
+	}
+
+	@Test
+	public void testGetClient() {
+		// Here could be tests to call the different permutations of CertTrustStrategy and HostnameVerification 
+	}
+
+	@Test
+	public void testGetTrustSelfsignedClient() throws KeyManagementException, NoSuchAlgorithmException, KeyStoreException {
+        String host = "";
+        int port = 443;
+        String scheme = "http";
+        if (port == 443) scheme = "https";
+        HttpHost target = new HttpHost(host, port, scheme);
+        CredentialsProvider credsProvider = new BasicCredentialsProvider();
+        credsProvider.setCredentials(
+                new AuthScope(target.getHostName(), target.getPort()),
+                new UsernamePasswordCredentials("", ""));
+        
+		Assert.assertNotNull(HttpClientFactory.getTrustSelfsignedClient(credsProvider));
+	}
+
+	@Test
+	public void testGetTrustAllClient() throws KeyManagementException, NoSuchAlgorithmException, KeyStoreException {
+        String host = "";
+        int port = 443;
+        String scheme = "http";
+        if (port == 443) scheme = "https";
+        HttpHost target = new HttpHost(host, port, scheme);
+        CredentialsProvider credsProvider = new BasicCredentialsProvider();
+        credsProvider.setCredentials(
+                new AuthScope(target.getHostName(), target.getPort()),
+                new UsernamePasswordCredentials("", ""));
+        
+		Assert.assertNotNull(HttpClientFactory.getTrustAllClient(credsProvider));
+	}
+
+}


### PR DESCRIPTION
allow more more flexible verification of hostnames and ssl-certs

while connecting to jira you now can
- disable any ssl-certificate checking
- trust all self signed ssl-certificates
- disable hostname-verification

@cschulc Hi Christian, mir wärs fast lieber du lehnst diesen PR ab. Das soll nur mal zeigen wie ichs gemacht habe und als Gesprächsbasis dienen. Ich habe z.B. keinen Test laufen lassen können weil ich die Infrastruktur dafür nicht aufgesetzt habe. Das ist also alles Drivebycoding :see_no_evil: 
